### PR TITLE
used #defined constants to specify reverse and turn delays

### DIFF
--- a/ZumoExamples/examples/BorderDetect/BorderDetect.ino
+++ b/ZumoExamples/examples/BorderDetect/BorderDetect.ino
@@ -14,7 +14,7 @@
 #define TURN_SPEED        200
 #define FORWARD_SPEED     200
 #define REVERSE_DURATION  200 // ms
-#define TURN_DURATION     400 // ms
+#define TURN_DURATION     300 // ms
  
 ZumoBuzzer buzzer;
 ZumoMotors motors;
@@ -70,18 +70,18 @@ void loop()
   {
     // if leftmost sensor detects line, reverse and turn to the right
     motors.setSpeeds(-REVERSE_SPEED, -REVERSE_SPEED);
-    delay(200);
+    delay(REVERSE_DURATION);
     motors.setSpeeds(TURN_SPEED, -TURN_SPEED);
-    delay(300);
+    delay(TURN_DURATION);
     motors.setSpeeds(FORWARD_SPEED, FORWARD_SPEED);
   }
   else if (sensor_values[5] < QTR_THRESHOLD)
   {
     // if rightmost sensor detects line, reverse and turn to the left
     motors.setSpeeds(-REVERSE_SPEED, -REVERSE_SPEED);
-    delay(200);
+    delay(REVERSE_DURATION);
     motors.setSpeeds(-TURN_SPEED, TURN_SPEED);
-    delay(300);
+    delay(TURN_DURATION);
     motors.setSpeeds(FORWARD_SPEED, FORWARD_SPEED);
   }
   else


### PR DESCRIPTION
Use the constants REVERSE_DURATION and TURN_DURATION, which had already been #defined, when specifying the delays for reversing and turning when executing a right or left turn.
